### PR TITLE
Fix ICS20 Fungible Token Transfer hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ you have to introduce the following features:
 [Building Apalache from source]: https://apalache.informal.systems/docs/apalache/installation/source.html
 [Apalache releases]: https://github.com/informalsystems/apalache/releases
 [step-by-step instructions]: ./docs/type-and-check.md 
-[ICS20]: https://github.com/cosmos/ics/tree/master/spec/ics-020-fungible-token-transfer
+[ICS20]: https://github.com/cosmos/ibc/tree/master/spec/app/ics-020-fungible-token-transfer


### PR DESCRIPTION
The current hyperlink leads to 404. I believe the file migrated from `./spec` to `./spec/app`.

Not sure why the root changed from `ics` to `ibc`, but going to `./cosmos/ics` redirects to `./cosmos/ibc`, so I assume the root folder was just renamed at some point.